### PR TITLE
Enable saving gallery images via animal endpoint

### DIFF
--- a/django/gompet_new/animals/serializers.py
+++ b/django/gompet_new/animals/serializers.py
@@ -139,7 +139,7 @@ class AnimalSerializer(serializers.ModelSerializer):
     # characteristics = AnimalCharacteristicSerializer(
     #     source="characteristics_values", many=True, read_only=True
     # )
-    gallery = AnimalGallerySerializer(many=True, read_only=True)
+    gallery = AnimalGallerySerializer(many=True, required=False)
     parents = serializers.SerializerMethodField(read_only=True)
     parentships = AnimalParentSerializer(many=True, read_only=True)
     offsprings = AnimalParentSerializer(many=True, read_only=True)
@@ -208,6 +208,22 @@ class AnimalSerializer(serializers.ModelSerializer):
         qs = AnimalParent.objects.filter(animal=obj)
         serializer = ParentWithGrandparentsSerializer(qs, many=True, context=self.context)
         return serializer.data
+
+    def create(self, validated_data):
+        gallery_data = validated_data.pop("gallery", [])
+        animal = super().create(validated_data)
+        for image_data in gallery_data:
+            AnimalGallery.objects.create(animal=animal, **image_data)
+        return animal
+
+    def update(self, instance, validated_data):
+        gallery_data = validated_data.pop("gallery", None)
+        animal = super().update(instance, validated_data)
+        if gallery_data is not None:
+            instance.gallery.all().delete()
+            for image_data in gallery_data:
+                AnimalGallery.objects.create(animal=animal, **image_data)
+        return animal
     
     
 


### PR DESCRIPTION
## Summary
- allow Animal endpoint to accept gallery images
- test creating animals with gallery entries

## Testing
- `python manage.py test animals.tests.AnimalGalleryCreateTest -v 2` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c52d801c832da9a56dbdc5101db3