### PR TITLE
Enable multiple image uploads in AnimalGallerySerializer

### DIFF
--- a/django/gompet_new/animals/tests.py
+++ b/django/gompet_new/animals/tests.py
@@ -74,3 +74,37 @@ class AnimalGalleryCreateTest(APITestCase):
         self.assertEqual(response.status_code, 201)
         animal_id = response.data["id"]
         self.assertEqual(AnimalGallery.objects.filter(animal_id=animal_id).count(), 1)
+
+
+class AnimalGalleryMultipleUploadTest(APITestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            email="user2@example.com",
+            password="password",
+            first_name="Test",
+            last_name="User",
+        )
+        self.client.force_authenticate(user=self.user)
+        self.animal = Animal.objects.create(
+            name="Multi",
+            species="dog",
+            gender=Gender.MALE,
+            size=Size.SMALL,
+        )
+
+    def test_upload_multiple_images(self):
+        image_data = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+        )
+        payload = {
+            "animal": self.animal.id,
+            "images": [
+                f"data:image/png;base64,{image_data}",
+                f"data:image/png;base64,{image_data}",
+            ],
+        }
+        response = self.client.post("/animals/galleries/", payload, format="json")
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            AnimalGallery.objects.filter(animal=self.animal).count(), 2
+        )


### PR DESCRIPTION
## Summary
- allow providing several images in `AnimalGallerySerializer` via new `images` field
- bulk-create `AnimalGallery` entries from uploaded images
- cover multiple image uploads with a new test

## Testing
- `pip install -r requirements.txt`
- `python manage.py test animals` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d9c43900832da4c5acdff77a9c83