### PR TITLE
Enable multipart parsing for animal gallery uploads

### DIFF
--- a/django/gompet_new/animals/api_views.py
+++ b/django/gompet_new/animals/api_views.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 
 from .models import (
     Animal,
@@ -53,6 +54,7 @@ class AnimalViewSet(viewsets.ModelViewSet):
     queryset = Animal.objects.all()
     serializer_class = AnimalSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
+    parser_classes = (MultiPartParser, FormParser, JSONParser)
 
     def perform_create(self, serializer):
         # automatycznie ustawia właściciela na zalogowanego użytkownika

--- a/django/gompet_new/animals/serializers.py
+++ b/django/gompet_new/animals/serializers.py
@@ -52,21 +52,17 @@ class AnimalCharacteristicSerializer(serializers.ModelSerializer):
 
 
 class AnimalGallerySerializer(serializers.ModelSerializer):
-    #image = Base64ImageField(required=False, allow_null=True)
-    
-    animal = serializers.PrimaryKeyRelatedField(
-        queryset=Animal.objects.all(), write_only=True, required=False
-    )
+    """Simple serializer for gallery images.
+
+    Only the ``image`` field is required when creating gallery items – the
+    associated ``Animal`` instance is supplied by ``AnimalSerializer`` during
+    creation.  The ``id`` field is read‑only and returned only in responses.
+    """
 
     class Meta:
         model = AnimalGallery
-        fields = (
-            "id",
-            "image",
-            
-            
-            #"ordering",
-        )
+        fields = ("id", "image")
+        read_only_fields = ("id",)
 
    
 


### PR DESCRIPTION
## Summary
- allow AnimalViewSet to parse multipart, form, and JSON payloads
- simplify AnimalGallerySerializer so gallery accepts list of objects with an image field

## Testing
- `python manage.py test animals` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68c1f9b3e92c832d9344a482d7fd88e1