### PR TITLE
Compute age from birth date and expose in API

### DIFF
--- a/django/gompet_new/animals/models.py
+++ b/django/gompet_new/animals/models.py
@@ -161,6 +161,17 @@ class Animal(models.Model):
         self.deleted_at = timezone.now()
         self.save(update_fields=["deleted_at"])
 
+    def save(self, *args, **kwargs):
+        """Calculate age from birth_date before saving."""
+        if self.birth_date:
+            today = timezone.now().date()
+            self.age = today.year - self.birth_date.year - (
+                (today.month, today.day) < (self.birth_date.month, self.birth_date.day)
+            )
+        else:
+            self.age = None
+        super().save(*args, **kwargs)
+
 
 # ────────────────────────────────────────────────────────────────────
 #  Charakterystyki / cechy boolowskie

--- a/django/gompet_new/animals/serializers.py
+++ b/django/gompet_new/animals/serializers.py
@@ -151,7 +151,7 @@ class CharacterItemSerializer(serializers.Serializer):
 
 class AnimalSerializer(serializers.ModelSerializer):
     owner = serializers.PrimaryKeyRelatedField(read_only=True)
-    #age = serializers.IntegerField(read_only=True)
+    age = serializers.IntegerField(read_only=True)
     image = Base64ImageField(required=False, allow_null=True)
     # use the correct related name to retrieve characteristic values
     # characteristics = AnimalCharacteristicSerializer(
@@ -351,7 +351,8 @@ class RecentlyAddedAnimalSerializer(serializers.ModelSerializer):
         many=True, source='characteristic_board', required=False
     )
     gender = serializers.CharField(read_only=True)
-    
+    age = serializers.IntegerField(read_only=True)
+
 
     size = serializers.CharField(read_only=True)
 

--- a/django/gompet_new/animals/tests.py
+++ b/django/gompet_new/animals/tests.py
@@ -55,6 +55,22 @@ class AnimalModelTests(TestCase):
         self.assertIsNotNone(animal.deleted_at)
 
 
+class AnimalSerializerAgeTests(TestCase):
+    """Tests for age field serialization."""
+
+    def test_serializer_returns_computed_age(self):
+        birth_date = timezone.now().date() - timedelta(days=3 * 365)
+        animal = Animal.objects.create(
+            name="Toby",
+            species="Dog",
+            gender=Gender.MALE,
+            size=Size.SMALL,
+            birth_date=birth_date,
+        )
+        data = AnimalSerializer(animal).data
+        self.assertEqual(data["age"], 3)
+
+
 class AnimalParentModelTests(TestCase):
     """Validations for AnimalParent relations."""
 


### PR DESCRIPTION
## Summary
- compute `Animal.age` from `birth_date` on save
- expose read-only `age` in animal serializers
- test age serialization

## Testing
- `python manage.py test animals` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68c32d02a6d8832db5024a8197fd261b