### PR TITLE
Fix AnimalParent serializer to accept animal and parent IDs

### DIFF
--- a/django/gompet_new/animals/serializers.py
+++ b/django/gompet_new/animals/serializers.py
@@ -82,8 +82,8 @@ class AnimalGallerySerializer(serializers.ModelSerializer):
 
 class AnimalParentSerializer(serializers.ModelSerializer):
     # both sides: `parent` if used under `parentships`, `animal` if under `offsprings`
-    parent = serializers.PrimaryKeyRelatedField(read_only=True)
-    animal = serializers.PrimaryKeyRelatedField(read_only=True)
+    parent = serializers.PrimaryKeyRelatedField(queryset=Animal.objects.all())
+    animal = serializers.PrimaryKeyRelatedField(queryset=Animal.objects.all())
 
     class Meta:
         model = AnimalParent

--- a/django/gompet_new/animals/tests.py
+++ b/django/gompet_new/animals/tests.py
@@ -16,7 +16,7 @@ from .models import (
     ParentRelation,
     Size,
 )
-from .serializers import AnimalSerializer
+from .serializers import AnimalSerializer, AnimalParentSerializer
 
 
 class AnimalModelTests(TestCase):
@@ -130,6 +130,36 @@ class AnimalParentModelTests(TestCase):
                 parent=self.other,
                 relation=ParentRelation.MOTHER,
             )
+
+
+class AnimalParentSerializerTests(TestCase):
+    """Tests for AnimalParentSerializer validation and saving."""
+
+    def setUp(self):
+        self.child = Animal.objects.create(
+            name="Junior",
+            species="Dog",
+            gender=Gender.MALE,
+            size=Size.SMALL,
+        )
+        self.mother = Animal.objects.create(
+            name="Mom",
+            species="Dog",
+            gender=Gender.FEMALE,
+            size=Size.MEDIUM,
+        )
+
+    def test_serializer_creates_relation_with_both_ids(self):
+        data = {
+            "animal": self.child.id,
+            "parent": self.mother.id,
+            "relation": ParentRelation.MOTHER,
+        }
+        serializer = AnimalParentSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        relation = serializer.save()
+        self.assertEqual(relation.animal, self.child)
+        self.assertEqual(relation.parent, self.mother)
 
 
 class AnimalGalleryModelTests(TestCase):


### PR DESCRIPTION
## Summary
- allow `AnimalParentSerializer` to save `animal` and `parent` IDs
- add tests for creating parent-child relations via serializer

## Testing
- `python manage.py test animals` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68c41458fbd8832dbdb72ce987a9abcf