### PR TITLE
Validate parent gender for relation

### DIFF
--- a/django/gompet_new/animals/tests.py
+++ b/django/gompet_new/animals/tests.py
@@ -131,6 +131,20 @@ class AnimalParentModelTests(TestCase):
                 relation=ParentRelation.MOTHER,
             )
 
+    def test_relation_matches_parent_gender(self):
+        with self.assertRaises(ValidationError):
+            AnimalParent.objects.create(
+                animal=self.child,
+                parent=self.mother,
+                relation=ParentRelation.FATHER,
+            )
+        with self.assertRaises(ValidationError):
+            AnimalParent.objects.create(
+                animal=self.child,
+                parent=self.father,
+                relation=ParentRelation.MOTHER,
+            )
+
 
 class AnimalParentSerializerTests(TestCase):
     """Tests for AnimalParentSerializer validation and saving."""


### PR DESCRIPTION
## Summary
- ensure AnimalParent relation matches parent's gender
- add tests for mismatched parent gender

## Testing
- `python django/gompet_new/manage.py test` *(fails: No module named 'gompet_new.settings')*


------
https://chatgpt.com/codex/tasks/task_e_68c4176361a4832d9606d286fe39d3b4