### PR TITLE
Validate parent birth date older than child

### DIFF
--- a/django/gompet_new/animals/models.py
+++ b/django/gompet_new/animals/models.py
@@ -284,6 +284,11 @@ class AnimalParent(models.Model):
             raise ValidationError(
                 f"Relacja '{self.relation}' nie pasuje do płci rodzica '{self.parent.gender}'."
             )
+        if self.parent.birth_date and self.animal.birth_date:
+            if self.parent.birth_date >= self.animal.birth_date:
+                raise ValidationError(
+                    "Rodzic musi być starszy od zwierzęcia."
+                )
         qs = self.__class__.objects.filter(animal=self.animal)
         if self.pk:
             qs = qs.exclude(pk=self.pk)

--- a/django/gompet_new/animals/tests.py
+++ b/django/gompet_new/animals/tests.py
@@ -145,6 +145,18 @@ class AnimalParentModelTests(TestCase):
                 relation=ParentRelation.MOTHER,
             )
 
+    def test_parent_must_be_older_than_child(self):
+        self.child.birth_date = timezone.now().date()
+        self.child.save()
+        self.mother.birth_date = self.child.birth_date + timedelta(days=1)
+        self.mother.save()
+        with self.assertRaises(ValidationError):
+            AnimalParent.objects.create(
+                animal=self.child,
+                parent=self.mother,
+                relation=ParentRelation.MOTHER,
+            )
+
 
 class AnimalParentSerializerTests(TestCase):
     """Tests for AnimalParentSerializer validation and saving."""


### PR DESCRIPTION
## Summary
- ensure parent animals are older than their offspring
- add regression test for younger parent rejection

## Testing
- `python manage.py test animals` (fails: ModuleNotFoundError: No module named 'gompet_new.settings')


------
https://chatgpt.com/codex/tasks/task_e_68c41a04fc04832dbefe741408193a08