### PR TITLE
Enable OPTIONS in AnimalParentViewSet

### DIFF
--- a/django/gompet_new/animals/api_views.py
+++ b/django/gompet_new/animals/api_views.py
@@ -462,6 +462,7 @@ class AnimalParentViewSet(viewsets.ModelViewSet):
     queryset = AnimalParent.objects.all()
     serializer_class = AnimalParentSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
+    http_method_names = ["get", "post", "put", "patch", "delete", "head", "options"]
 
 @extend_schema(
     tags=["animal_family_tree"],


### PR DESCRIPTION
## Summary
- allow OPTIONS requests in AnimalParentViewSet by explicitly listing supported HTTP methods

## Testing
- `python manage.py test animals` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68c42614ba9c832db911e50b11d63a72