### PR TITLE
Disable pagination for Animal list endpoint

### DIFF
--- a/django/gompet_new/animals/api_views.py
+++ b/django/gompet_new/animals/api_views.py
@@ -90,8 +90,16 @@ Wymaga importów i konfiguracji GeoDjango: from django.contrib.gis.measure impor
     serializer_class = AnimalSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
     parser_classes = (MultiPartParser, FormParser, JSONParser)
+    # Disable pagination so list endpoints return plain arrays.
+    pagination_class = None
     # DEFAULT_LIMIT = 10
     # MAX_LIMIT = 50
+
+    def list(self, request, *args, **kwargs):
+        """Return a plain list of serialized animals without pagination."""
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
     def perform_create(self, serializer):
         # automatycznie ustawia właściciela na zalogowanego użytkownika


### PR DESCRIPTION
## Summary
- avoid returning paginated responses from the main animal list endpoint by disabling pagination on `AnimalViewSet`
- override the list action to always emit a flat JSON array

## Testing
- `pytest animals/tests.py::AnimalViewSetGeoFilteringTests::test_filter_animals_by_location -q` *(fails: Could not find the GDAL library (tried "gdal", "GDAL", "gdal3.10.0", "gdal3.9.0", "gdal3.8.0", "gdal3.7.0", "gdal3.6.0", "gdal3.5.0", "gdal3.4.0", "gdal3.3.0", "gdal3.2.0", "gdal3.1.0"))*
- `pytest animals/tests.py::AnimalViewSetGeoFilteringTests::test_filter_animals_by_range -q` *(fails: Could not find the GDAL library (tried "gdal", "GDAL", "gdal3.10.0", "gdal3.9.0", "gdal3.8.0", "gdal3.7.0", "gdal3.6.0", "gdal3.5.0", "gdal3.4.0", "gdal3.3.0", "gdal3.2.0", "gdal3.1.0"))*

------
https://chatgpt.com/codex/tasks/task_e_68c48cf92160832da01ff37cdd74bbbf