### PR TITLE
Allow nested parent creation in AnimalSerializer

### DIFF
--- a/django/gompet_new/animals/serializers.py
+++ b/django/gompet_new/animals/serializers.py
@@ -15,6 +15,7 @@ from django.contrib.gis.db.models.functions import Distance
 from users.serializers import OrganizationSerializer
 
 from .models import ParentRelation
+from django.db import transaction
 
 
 class Base64ImageField(serializers.ImageField):
@@ -86,7 +87,9 @@ class AnimalGallerySerializer(serializers.ModelSerializer):
 class AnimalParentSerializer(serializers.ModelSerializer):
     # both sides: `parent` if used under `parentships`, `animal` if under `offsprings`
     parent = serializers.PrimaryKeyRelatedField(queryset=Animal.objects.all())
-    animal = serializers.PrimaryKeyRelatedField(queryset=Animal.objects.all())
+    animal = serializers.PrimaryKeyRelatedField(
+        queryset=Animal.objects.all(), required=False, write_only=True
+    )
     relation = serializers.ChoiceField(choices=ParentRelation.choices)
 
     class Meta:
@@ -166,7 +169,7 @@ class AnimalSerializer(serializers.ModelSerializer):
     # be optional during validation.
     gallery = AnimalGallerySerializer(many=True, required=False)
     parents = serializers.SerializerMethodField(read_only=True)
-    #parentships = AnimalParentSerializer(many=True, read_only=True)
+    parentships = AnimalParentSerializer(many=True, required=False)
     #offsprings = AnimalParentSerializer(many=True, read_only=True)
     comments = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
     reactions = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
@@ -206,10 +209,10 @@ class AnimalSerializer(serializers.ModelSerializer):
             "life_period",
             "characteristicBoard",
             "gallery",
-            #"parentships",
+            "parentships",
             #"offsprings",
-            
-           
+
+
             "comments",
             "reactions",
             "organization",
@@ -240,6 +243,14 @@ class AnimalSerializer(serializers.ModelSerializer):
         serializer = ParentWithGrandparentsSerializer(qs, many=True, context=self.context)
         return serializer.data
 
+    def validate_parentships(self, value):
+        if len(value) > 2:
+            raise serializers.ValidationError("Zwierzę może mieć maksymalnie dwóch rodziców.")
+        relations = [item["relation"] for item in value]
+        if len(relations) != len(set(relations)):
+            raise serializers.ValidationError("Relacje rodziców muszą być unikalne.")
+        return value
+
     def validate_gallery(self, value):
         """Ensure every provided gallery item includes an image.
 
@@ -259,28 +270,48 @@ class AnimalSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(missing)
         return value
 
+    @transaction.atomic
     def create(self, validated_data):
         gallery = validated_data.pop("gallery", [])
+        parentships = validated_data.pop("parentships", [])
         animal = super().create(validated_data)
-        for i, item in enumerate(gallery):
+        for item in gallery:
             AnimalGallery.objects.create(
                 animal=animal,
                 image=item.get("image"),
-                
+
             )
+        for item in parentships:
+            data = dict(item)
+            data["parent"] = data["parent"].id
+            data["animal"] = animal.id
+            serializer = AnimalParentSerializer(data=data)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
         return animal
 
+    @transaction.atomic
     def update(self, instance, validated_data):
         gallery = validated_data.pop("gallery", None)
+        parentships = validated_data.pop("parentships", None)
         animal = super().update(instance, validated_data)
         if gallery is not None:
             instance.gallery.all().delete()
-            for i, item in enumerate(gallery):
+            for item in gallery:
                 AnimalGallery.objects.create(
                     animal=animal,
                     image=item.get("image"),
-                    
+
                 )
+        if parentships is not None:
+            instance.parentships.all().delete()
+            for item in parentships:
+                data = dict(item)
+                data["parent"] = data["parent"].id
+                data["animal"] = animal.id
+                serializer = AnimalParentSerializer(data=data)
+                serializer.is_valid(raise_exception=True)
+                serializer.save()
         return animal
     
     

--- a/django/gompet_new/animals/tests.py
+++ b/django/gompet_new/animals/tests.py
@@ -192,6 +192,46 @@ class AnimalParentSerializerTests(TestCase):
         self.assertEqual(relation.parent, self.mother)
 
 
+class AnimalSerializerParentCreationTests(TestCase):
+    """Ensure AnimalSerializer can create parent relations."""
+
+    def setUp(self):
+        self.mother = Animal.objects.create(
+            name="Mom",
+            species="Dog",
+            gender=Gender.FEMALE,
+            size=Size.MEDIUM,
+        )
+        self.father = Animal.objects.create(
+            name="Dad",
+            species="Dog",
+            gender=Gender.MALE,
+            size=Size.MEDIUM,
+        )
+
+    def test_creates_parentships_during_animal_creation(self):
+        data = {
+            "name": "Puppy",
+            "species": "Dog",
+            "gender": Gender.MALE,
+            "size": Size.SMALL,
+            "parentships": [
+                {"parent": self.mother.id, "relation": ParentRelation.MOTHER},
+                {"parent": self.father.id, "relation": ParentRelation.FATHER},
+            ],
+        }
+        serializer = AnimalSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        animal = serializer.save()
+        self.assertEqual(animal.parentships.count(), 2)
+        self.assertTrue(
+            animal.parentships.filter(parent=self.mother, relation=ParentRelation.MOTHER).exists()
+        )
+        self.assertTrue(
+            animal.parentships.filter(parent=self.father, relation=ParentRelation.FATHER).exists()
+        )
+
+
 class AnimalGalleryModelTests(TestCase):
     """Basic tests for AnimalGallery model."""
 


### PR DESCRIPTION
## Summary
- Allow `AnimalSerializer` to accept `parentships` for inline parent relations
- Validate parent count and relation uniqueness
- Save parent links during animal create/update and add corresponding tests

## Testing
- `python django/gompet_new/manage.py test animals -v 2` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*
- `pytest django/gompet_new/animals/tests.py::AnimalSerializerParentCreationTests -q` *(fails: django.core.exceptions.ImproperlyConfigured: Could not find the GDAL library)*


------
https://chatgpt.com/codex/tasks/task_e_68c54bab0f04832d80c6608f13f1d5fa