### PR TITLE
Support ContentType natural keys in serializers

### DIFF
--- a/django/gompet_new/common/serializers.py
+++ b/django/gompet_new/common/serializers.py
@@ -1,16 +1,32 @@
 
 from rest_framework import serializers
 from django.contrib.contenttypes.models import ContentType
-from django.utils import timezone
 from common.models import Comment, Reaction, ReactionType
 
 
+class ContentTypeRelatedField(serializers.PrimaryKeyRelatedField):
+    """Field accepting ContentType by PK or "app_label.model" string."""
+
+    def __init__(self, **kwargs):
+        super().__init__(queryset=ContentType.objects.all(), **kwargs)
+
+    def to_internal_value(self, data):
+        if isinstance(data, str) and "." in data:
+            app_label, model = data.split(".", 1)
+            app_label = app_label.lower()
+            model = model.lower()
+            try:
+                return self.get_queryset().get(
+                    app_label=app_label, model=model
+                )
+            except ContentType.DoesNotExist:
+                self.fail("does_not_exist", pk_value=data)
+        return super().to_internal_value(data)
+
 
 class CommentSerializer(serializers.ModelSerializer):
-    # wybieramy ContentType po its PK
-    content_type = serializers.PrimaryKeyRelatedField(
-        queryset=ContentType.objects.all()
-    )
+    # wybieramy ContentType po its PK lub etykiecie "app_label.model"
+    content_type = ContentTypeRelatedField()
     # użytkownik z request.user (ukryte pole)
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
@@ -38,9 +54,7 @@ class CommentSerializer(serializers.ModelSerializer):
 
 
 class ReactionSerializer(serializers.ModelSerializer):
-    reactable_type = serializers.PrimaryKeyRelatedField(
-        queryset=ContentType.objects.all()
-    )
+    reactable_type = ContentTypeRelatedField()
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
     class Meta:


### PR DESCRIPTION
## Summary
- add a reusable `ContentTypeRelatedField` that resolves content types by primary key or `app_label.model`
- use the new field for comment and reaction serializers so clients can send the natural key string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3a18346c0832db4eb864651ed01c8