### PR TITLE
Add websocket like counter for reactables

### DIFF
--- a/django/gompet_new/common/__init__.py
+++ b/django/gompet_new/common/__init__.py
@@ -1,0 +1,3 @@
+default_app_config = "common.apps.CommonConfig"
+
+__all__ = ["default_app_config"]

--- a/django/gompet_new/common/apps.py
+++ b/django/gompet_new/common/apps.py
@@ -2,5 +2,12 @@ from django.apps import AppConfig
 
 
 class CommonConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'common'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "common"
+
+    def ready(self) -> None:  # pragma: no cover - import side effects only
+        # Importujemy sygnały przy starcie aplikacji aby zapewnić rejestrację
+        # nasłuchiwaczy post_save/post_delete dla modelu Reaction.
+        from . import signals  # noqa: F401
+
+        return super().ready()

--- a/django/gompet_new/common/consumers.py
+++ b/django/gompet_new/common/consumers.py
@@ -1,0 +1,68 @@
+"""Websocket consumer obsługujący licznik polubień."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+
+from .like_counter import ReactableRef, build_payload, make_group_name, resolve_content_type
+
+logger = logging.getLogger(__name__)
+
+
+class LikeCounterConsumer(AsyncJsonWebsocketConsumer):
+    """Udostępnia liczbę polubień dla wskazanego obiektu."""
+
+    content_type: ContentType
+    reactable_id: int
+    group_name: str
+
+    async def connect(self) -> None:
+        try:
+            reactable_type = self.scope["url_route"]["kwargs"]["reactable_type"]
+            reactable_id_raw = self.scope["url_route"]["kwargs"]["reactable_id"]
+        except KeyError as exc:  # pragma: no cover - ochronny guard
+            logger.warning("Brak wymaganych parametrów w ścieżce websocket: %s", exc)
+            await self.close(code=4400)
+            return
+
+        try:
+            self.reactable_id = int(reactable_id_raw)
+        except (TypeError, ValueError):
+            await self.close(code=4400)
+            return
+
+        try:
+            self.content_type = await database_sync_to_async(resolve_content_type)(reactable_type)
+        except ContentType.DoesNotExist:
+            await self.close(code=4404)
+            return
+
+        self.group_name = make_group_name(self.content_type.pk, self.reactable_id)
+
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+        await self._send_current_state()
+
+    async def disconnect(self, code: int) -> None:  # noqa: D401 - API channels
+        await self.channel_layer.group_discard(self.group_name, self.channel_name)
+        await super().disconnect(code)
+
+    async def _send_current_state(self) -> None:
+        payload = await database_sync_to_async(self._build_payload)()
+        await self.send_json(payload)
+
+    def _build_payload(self) -> dict[str, Any]:
+        ref = ReactableRef(content_type=self.content_type, object_id=self.reactable_id)
+        return build_payload(ref)
+
+    async def receive_json(self, content: Any, **kwargs: Any) -> None:  # pragma: no cover - API read-only
+        raise ValidationError("Ten websocket służy wyłącznie do odczytu.")
+
+    async def like_count_update(self, event: dict[str, Any]) -> None:
+        await self.send_json(event["payload"])

--- a/django/gompet_new/common/like_counter.py
+++ b/django/gompet_new/common/like_counter.py
@@ -1,0 +1,85 @@
+"""Helpers obsługujące licznik reakcji typu LIKE."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import QuerySet
+
+from .models import Reaction, ReactionType
+
+
+@dataclass(slots=True)
+class ReactableRef:
+    """Reprezentuje obiekt, dla którego liczymy reakcje."""
+
+    content_type: ContentType
+    object_id: int
+
+    @property
+    def natural_key(self) -> str:
+        return f"{self.content_type.app_label}.{self.content_type.model}"
+
+
+def resolve_content_type(value: Any) -> ContentType:
+    """Zwraca ``ContentType`` niezależnie od tego jaką postać przyjmie ``value``."""
+
+    if isinstance(value, ContentType):
+        return value
+
+    if isinstance(value, int):
+        return ContentType.objects.get(pk=value)
+
+    if isinstance(value, str):
+        if value.isdigit():
+            return ContentType.objects.get(pk=int(value))
+        if "." in value:
+            app_label, model = value.split(".", 1)
+            return ContentType.objects.get(app_label=app_label, model=model)
+
+    raise ContentType.DoesNotExist(value)
+
+
+def like_queryset(ref: ReactableRef) -> QuerySet[Reaction]:
+    """Queryset z wszystkimi reakcjami LIKE dla wskazanego obiektu."""
+
+    return Reaction.objects.filter(
+        reactable_type=ref.content_type,
+        reactable_id=ref.object_id,
+        reaction_type=ReactionType.LIKE,
+    )
+
+
+def calculate_like_total(ref: ReactableRef) -> int:
+    """Zwraca liczbę reakcji LIKE."""
+
+    return like_queryset(ref).count()
+
+
+def make_group_name(content_type_id: int, object_id: int) -> str:
+    """Kanał grupowy używany do wysyłki aktualizacji liczby polubień."""
+
+    return f"like_counter:{content_type_id}:{object_id}"
+
+
+def build_payload(ref: ReactableRef) -> dict[str, Any]:
+    """Sformatowany payload do wysłania przez websocket."""
+
+    return {
+        "reactable": {
+            "id": ref.object_id,
+            "type": ref.natural_key,
+        },
+        "total_likes": calculate_like_total(ref),
+    }
+
+
+__all__ = [
+    "ReactableRef",
+    "resolve_content_type",
+    "calculate_like_total",
+    "make_group_name",
+    "build_payload",
+]

--- a/django/gompet_new/common/routing.py
+++ b/django/gompet_new/common/routing.py
@@ -1,0 +1,19 @@
+"""Ścieżki websocket dla aplikacji ``common``."""
+
+from __future__ import annotations
+
+from django.urls import re_path
+
+from . import consumers
+
+
+websocket_urlpatterns = [
+    re_path(
+        r"^ws/reactable/(?P<reactable_type>[^/]+)/(?P<reactable_id>\d+)/$",
+        consumers.LikeCounterConsumer.as_asgi(),
+        name="like-counter",
+    ),
+]
+
+
+__all__ = ["websocket_urlpatterns"]

--- a/django/gompet_new/common/signals.py
+++ b/django/gompet_new/common/signals.py
@@ -1,0 +1,85 @@
+"""Sygnały aktualizujące licznik polubień."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from asgiref.sync import async_to_sync
+from channels.exceptions import InvalidChannelLayerError
+from channels.layers import get_channel_layer
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models.signals import post_delete, post_save, pre_save
+from django.dispatch import receiver
+
+from .like_counter import ReactableRef, build_payload, make_group_name, resolve_content_type
+from .models import Reaction, ReactionType
+
+logger = logging.getLogger(__name__)
+
+
+def broadcast_like_count(reactable_type: Any, reactable_id: int) -> bool:
+    """Wysyła aktualną liczbę polubień do odpowiedniej grupy websocket."""
+
+    try:
+        content_type = resolve_content_type(reactable_type)
+    except ContentType.DoesNotExist:
+        logger.warning("Nie znaleziono ContentType dla wartości %s", reactable_type)
+        return False
+
+    ref = ReactableRef(content_type=content_type, object_id=reactable_id)
+    payload = build_payload(ref)
+
+    try:
+        channel_layer = get_channel_layer()
+    except (InvalidChannelLayerError, ImproperlyConfigured) as exc:
+        logger.debug("Kanał warstwy websocket niedostępny: %s", exc)
+        return False
+
+    if channel_layer is None:
+        return False
+
+    group_name = make_group_name(content_type.pk, reactable_id)
+    async_to_sync(channel_layer.group_send)(
+        group_name,
+        {
+            "type": "like_count_update",
+            "payload": payload,
+        },
+    )
+    return True
+
+
+@receiver(pre_save, sender=Reaction)
+def remember_previous_reaction_type(sender, instance: Reaction, **kwargs: Any) -> None:
+    if not instance.pk:
+        instance._previous_reaction_type = None
+        return
+
+    try:
+        previous = Reaction.objects.get(pk=instance.pk)
+    except Reaction.DoesNotExist:
+        instance._previous_reaction_type = None
+    else:
+        instance._previous_reaction_type = previous.reaction_type
+
+
+@receiver(post_save, sender=Reaction)
+def handle_reaction_saved(sender, instance: Reaction, **kwargs: Any) -> None:
+    previous_type = getattr(instance, "_previous_reaction_type", None)
+
+    if instance.reaction_type == ReactionType.LIKE or previous_type == ReactionType.LIKE:
+        broadcast_like_count(instance.reactable_type, instance.reactable_id)
+
+    if hasattr(instance, "_previous_reaction_type"):
+        delattr(instance, "_previous_reaction_type")
+
+
+@receiver(post_delete, sender=Reaction)
+def handle_reaction_deleted(sender, instance: Reaction, **kwargs: Any) -> None:
+    if instance.reaction_type == ReactionType.LIKE:
+        broadcast_like_count(instance.reactable_type, instance.reactable_id)
+
+
+__all__ = ["broadcast_like_count"]

--- a/django/gompet_new/common/tests.py
+++ b/django/gompet_new/common/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/django/gompet_new/common/tests/test_like_counter.py
+++ b/django/gompet_new/common/tests/test_like_counter.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from animals.models import Animal, Gender, Size
+from common.like_counter import ReactableRef, build_payload, make_group_name, resolve_content_type
+from common.models import Reaction, ReactionType
+from common.signals import broadcast_like_count
+
+
+class LikeCounterHelpersTests(TestCase):
+    def setUp(self) -> None:
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            email="user@example.com",
+            password="secret",
+            first_name="Jane",
+            last_name="Doe",
+        )
+        self.animal = Animal.objects.create(
+            name="Burek",
+            species="dog",
+            gender=Gender.MALE,
+            size=Size.MEDIUM,
+        )
+        self.content_type = ContentType.objects.get_for_model(Animal)
+
+    def test_make_group_name(self) -> None:
+        group = make_group_name(self.content_type.id, self.animal.id)
+        self.assertEqual(group, f"like_counter:{self.content_type.id}:{self.animal.id}")
+
+    def test_resolve_content_type_accepts_natural_key(self) -> None:
+        value = f"{self.content_type.app_label}.{self.content_type.model}"
+        resolved = resolve_content_type(value)
+        self.assertEqual(resolved, self.content_type)
+
+    def test_build_payload_counts_likes(self) -> None:
+        Reaction.objects.create(
+            user=self.user,
+            reaction_type=ReactionType.LIKE,
+            reactable_type=self.content_type,
+            reactable_id=self.animal.id,
+        )
+
+        ref = ReactableRef(content_type=self.content_type, object_id=self.animal.id)
+        payload = build_payload(ref)
+
+        self.assertEqual(payload["total_likes"], 1)
+        self.assertEqual(payload["reactable"], {
+            "id": self.animal.id,
+            "type": f"{self.content_type.app_label}.{self.content_type.model}",
+        })
+
+    @mock.patch("common.signals.get_channel_layer")
+    def test_broadcast_like_count_sends_payload(self, mocked_layer_getter: mock.Mock) -> None:
+        Reaction.objects.create(
+            user=self.user,
+            reaction_type=ReactionType.LIKE,
+            reactable_type=self.content_type,
+            reactable_id=self.animal.id,
+        )
+
+        mocked_layer = mock.Mock()
+        mocked_layer.group_send = mock.AsyncMock()
+        mocked_layer_getter.return_value = mocked_layer
+
+        sent = broadcast_like_count(self.content_type, self.animal.id)
+
+        self.assertTrue(sent)
+        mocked_layer.group_send.assert_awaited_once()
+        args, _ = mocked_layer.group_send.await_args
+        self.assertEqual(args[1]["payload"]["total_likes"], 1)
+
+    @mock.patch("common.signals.get_channel_layer", return_value=None)
+    def test_broadcast_like_count_returns_false_without_layer(self, mocked_layer_getter: mock.Mock) -> None:
+        self.assertFalse(broadcast_like_count(self.content_type, self.animal.id))

--- a/django/gompet_new/gompet_new/asgi.py
+++ b/django/gompet_new/gompet_new/asgi.py
@@ -1,16 +1,26 @@
-"""
-ASGI config for gompet_new project.
+"""Konfiguracja ASGI z obsługą kanałów websocket."""
 
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
-"""
+from __future__ import annotations
 
 import os
 
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gompet_new.settings')
+from common import routing as common_routing
 
-application = get_asgi_application()
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gompet_new.settings")
+
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": AuthMiddlewareStack(
+            URLRouter(common_routing.websocket_urlpatterns)
+        ),
+    }
+)
+
+__all__ = ["application"]


### PR DESCRIPTION
## Summary
- add reusable helpers for computing like counts and websocket group names
- expose a Channels consumer and routing for real-time like counter updates
- broadcast like count changes via Django signals and cover logic with unit tests

## Testing
- `python manage.py test common` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68d646f73ab0832d9a96b79ceea52da7