### PR TITLE
Handle group_send TypeErrors in like counter broadcast

### DIFF
--- a/django/gompet_new/common/signals.py
+++ b/django/gompet_new/common/signals.py
@@ -41,13 +41,22 @@ def broadcast_like_count(reactable_type: Any, reactable_id: int) -> bool:
         return False
 
     group_name = make_group_name(content_type.pk, reactable_id)
-    async_to_sync(channel_layer.group_send)(
-        group_name,
-        {
-            "type": "like_count_update",
-            "payload": payload,
-        },
-    )
+    try:
+        async_to_sync(channel_layer.group_send)(
+            group_name,
+            {
+                "type": "like_count_update",
+                "payload": payload,
+            },
+        )
+    except TypeError as exc:
+        logger.debug(
+            "Nie udało się wysłać aktualizacji licznika polubień: %s",
+            exc,
+            exc_info=True,
+        )
+        return False
+
     return True
 
 


### PR DESCRIPTION
## Summary
- guard the like counter broadcast helper against synchronous channel layer mocks
- return False when the group_send call raises a TypeError and log the failure for debugging

## Testing
- python manage.py test common.tests.test_like_counter *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68d64aab7eb0832d890606d249ac66fd