### PR TITLE
Fix ASGI import order for Channels routing

### DIFF
--- a/django/gompet_new/gompet_new/asgi.py
+++ b/django/gompet_new/gompet_new/asgi.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import os
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gompet_new.settings")
+
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 
-from common import routing as common_routing
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gompet_new.settings")
-
 django_asgi_app = get_asgi_application()
+
+from common import routing as common_routing
 
 application = ProtocolTypeRouter(
     {


### PR DESCRIPTION
## Summary
- ensure the Django settings module is configured before importing Channels routing
- defer importing the common websocket routing until after the ASGI app is initialised

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64c625efc832db1fc17162573b786