### PR TITLE
Fix websocket group name format

### DIFF
--- a/django/gompet_new/common/like_counter.py
+++ b/django/gompet_new/common/like_counter.py
@@ -61,7 +61,7 @@ def calculate_like_total(ref: ReactableRef) -> int:
 def make_group_name(content_type_id: int, object_id: int) -> str:
     """Kanał grupowy używany do wysyłki aktualizacji liczby polubień."""
 
-    return f"like_counter:{content_type_id}:{object_id}"
+    return f"like_counter.{content_type_id}.{object_id}"
 
 
 def build_payload(ref: ReactableRef) -> dict[str, Any]:

--- a/django/gompet_new/common/tests/test_like_counter.py
+++ b/django/gompet_new/common/tests/test_like_counter.py
@@ -31,7 +31,7 @@ class LikeCounterHelpersTests(TestCase):
 
     def test_make_group_name(self) -> None:
         group = make_group_name(self.content_type.id, self.animal.id)
-        self.assertEqual(group, f"like_counter:{self.content_type.id}:{self.animal.id}")
+        self.assertEqual(group, f"like_counter.{self.content_type.id}.{self.animal.id}")
 
     def test_resolve_content_type_accepts_natural_key(self) -> None:
         value = f"{self.content_type.app_label}.{self.content_type.model}"


### PR DESCRIPTION
## Summary
- replace the colon-delimited websocket group name with a dot-delimited version that satisfies Channels requirements
- update the like counter helper test to expect the new group name format

## Testing
- ⚠️ `python manage.py test common.tests.test_like_counter` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*


------
https://chatgpt.com/codex/tasks/task_e_68d65165e338832daa8cb57c12b4a1fb