### PR TITLE
Add endpoint to remove like reactions

### DIFF
--- a/django/gompet_new/common/api_views.py
+++ b/django/gompet_new/common/api_views.py
@@ -1,16 +1,14 @@
-from rest_framework import viewsets, permissions
 from django.contrib.contenttypes.models import ContentType
-from common.models import Comment, Reaction
-from .serializers import CommentSerializer, ContentTypeSerializer, ReactionSerializer
-
-
 
 from drf_spectacular.utils import extend_schema
+from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework import permissions
-from rest_framework import serializers, viewsets, permissions
+
+from common.like_counter import resolve_content_type
+from common.models import Comment, Reaction, ReactionType
+
+from .serializers import CommentSerializer, ContentTypeSerializer, ReactionSerializer
 
 # common/api_serializers.py
 
@@ -126,5 +124,43 @@ class ReactionViewSet(viewsets.ModelViewSet):
                 queryset = queryset.filter(reactable_type_id=reactable_type)
             
         return queryset
+
+    @action(detail=False, methods=["delete"], url_path="like", url_name="remove-like")
+    def remove_like(self, request):
+        """Usuwa reakcję LIKE bieżącego użytkownika dla wskazanego obiektu."""
+
+        reactable_type = request.data.get("reactable_type") or request.query_params.get("reactable_type")
+        reactable_id = request.data.get("reactable_id") or request.query_params.get("reactable_id")
+
+        if reactable_type is None or reactable_id is None:
+            return Response(
+                {"detail": "Fields 'reactable_type' and 'reactable_id' are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            content_type = resolve_content_type(reactable_type)
+        except ContentType.DoesNotExist:
+            return Response(
+                {"detail": "Invalid 'reactable_type'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            reactable_id_int = int(reactable_id)
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "Invalid 'reactable_id'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        Reaction.objects.filter(
+            user=request.user,
+            reaction_type=ReactionType.LIKE,
+            reactable_type=content_type,
+            reactable_id=reactable_id_int,
+        ).delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/django/gompet_new/common/tests/test_reaction_api.py
+++ b/django/gompet_new/common/tests/test_reaction_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework.test import APIClient
+
+from animals.models import Animal, Gender, Size
+from common.models import Reaction, ReactionType
+
+
+class ReactionViewSetTests(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            email="like@example.com",
+            password="secret",
+            first_name="Like",
+            last_name="Tester",
+        )
+        self.client.force_authenticate(self.user)
+
+        self.animal = Animal.objects.create(
+            name="Lubiak",
+            species="Dog",
+            gender=Gender.MALE,
+            size=Size.MEDIUM,
+        )
+        self.content_type = ContentType.objects.get_for_model(Animal)
+        self.remove_like_url = reverse("reaction-remove-like")
+
+    def test_remove_like_deletes_existing_reaction(self) -> None:
+        Reaction.objects.create(
+            user=self.user,
+            reaction_type=ReactionType.LIKE,
+            reactable_type=self.content_type,
+            reactable_id=self.animal.id,
+        )
+
+        response = self.client.delete(
+            self.remove_like_url,
+            {
+                "reactable_type": f"{self.content_type.app_label}.{self.content_type.model}",
+                "reactable_id": self.animal.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(
+            Reaction.objects.filter(
+                user=self.user,
+                reaction_type=ReactionType.LIKE,
+                reactable_type=self.content_type,
+                reactable_id=self.animal.id,
+            ).exists()
+        )
+
+    def test_remove_like_requires_parameters(self) -> None:
+        response = self.client.delete(self.remove_like_url, {}, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("detail", response.data)


### PR DESCRIPTION
## Summary
- add a custom ReactionViewSet action to remove the current user's LIKE reaction for a given object
- reuse the content type resolver to validate inputs and return appropriate errors when data is missing or invalid
- cover the new endpoint with API tests ensuring deletion and validation behavior

## Testing
- python manage.py test common *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68d654cf1660832dbe813af7099cc3b2