### PR TITLE
Restrict deletion of posts to authors or admins

### DIFF
--- a/django/gompet_new/posts/api_views.py
+++ b/django/gompet_new/posts/api_views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from .models import Post
 from .serializers import PostSerializer
@@ -70,3 +71,11 @@ class PostViewSet(viewsets.ModelViewSet):
         if organization_id:
             qs = qs.filter(organization_id=organization_id)
         return qs
+
+    def perform_destroy(self, instance):
+        user = self.request.user
+        if not user.is_staff and instance.author_id != user.id:
+            raise PermissionDenied(
+                "Tylko autor posta lub administrator może go usunąć."
+            )
+        super().perform_destroy(instance)


### PR DESCRIPTION
## Summary
- prevent unauthorized users from deleting posts by checking author or admin status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d96ea610c8832d8b66eb3d4bb3219c