### PR TITLE
Ensure reactions are removed when deleting posts

### DIFF
--- a/django/gompet_new/posts/models.py
+++ b/django/gompet_new/posts/models.py
@@ -115,4 +115,5 @@ class Post(TimeStampedModel):
         db_alias = using or self._state.db or router.db_for_write(type(self), instance=self)
         with transaction.atomic(using=db_alias):
             self.comments.using(db_alias).all().delete()
+            self.reactions.using(db_alias).all().delete()
             return super().delete(using=db_alias, keep_parents=keep_parents)


### PR DESCRIPTION
## Summary
- remove both comments and reactions when deleting a post to avoid orphaned generic relations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7f7dcafc832dbe50baa02f9ea26d