### PR TITLE
Cascade deletion for article relations

### DIFF
--- a/django/gompet_new/articles/tests.py
+++ b/django/gompet_new/articles/tests.py
@@ -1,3 +1,60 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+from common.models import Comment, Reaction, ReactionType
+
+from .models import Article
+
+
+class ArticleDeletionTests(TestCase):
+    """Ensure article deletion handles related generic data."""
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            email="author@example.com",
+            password="testpass123",
+            first_name="Author",
+            last_name="User",
+        )
+
+    def _create_article_with_relations(self, slug: str = "test-article"):
+        article = Article.objects.create(
+            slug=slug,
+            title="Test Article",
+            content="Content",
+            author=self.user,
+        )
+        comment = Comment.objects.create(
+            user=self.user,
+            content_object=article,
+            body="Comment",
+        )
+        reaction = Reaction.objects.create(
+            user=self.user,
+            reactable_object=article,
+            reaction_type=ReactionType.LIKE,
+        )
+        return article, comment, reaction
+
+    def test_soft_delete_marks_related_items(self):
+        article, comment, reaction = self._create_article_with_relations("soft-delete-article")
+
+        article.soft_delete()
+
+        article.refresh_from_db()
+        comment.refresh_from_db()
+        reaction.refresh_from_db()
+
+        self.assertIsNotNone(article.deleted_at)
+        self.assertIsNotNone(comment.deleted_at)
+        self.assertIsNotNone(reaction.deleted_at)
+
+    def test_delete_removes_related_items(self):
+        article, comment, reaction = self._create_article_with_relations("hard-delete-article")
+
+        article.delete()
+
+        self.assertFalse(Article.objects.filter(pk=article.pk).exists())
+        self.assertFalse(Comment.objects.filter(pk=comment.pk).exists())
+        self.assertFalse(Reaction.objects.filter(pk=reaction.pk).exists())


### PR DESCRIPTION
## Summary
- update the `Article` model to soft-delete related comments and reactions when an article is removed
- ensure hard deletion also cascades to generic relations for articles
- add tests that cover both soft and hard deletion paths for articles

## Testing
- `python manage.py test articles` *(fails: ModuleNotFoundError: No module named 'gompet_new.settings')*

------
https://chatgpt.com/codex/tasks/task_e_68da816087fc832dbc0f12b73bea7dc0