### PR TITLE
Add species filter to AnimalsBreedGroupsViewSet

### DIFF
--- a/django/gompet_new/animals/api_views.py
+++ b/django/gompet_new/animals/api_views.py
@@ -1044,5 +1044,7 @@ class AnimalsBreedGroupsViewSet(viewsets.ModelViewSet):
     queryset = AnimalsBreedGroups.objects.all()
     serializer_class = AnimalsBreedGroupsSerializer
     permission_classes = [OrganizationRolePermissions]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["species"]
 
     


### PR DESCRIPTION
### Motivation
- Allow API consumers to filter animal breed groups by `species` through the existing breed-groups endpoint.

### Description
- Enabled `DjangoFilterBackend` and added `filterset_fields = ["species"]` on `AnimalsBreedGroupsViewSet` in `django/gompet_new/animals/api_views.py` so requests like `GET /animals/animal-breed/?species=<id>` return only matching groups.

### Testing
- Ran `python django/gompet_new/manage.py check`, which could not complete in this environment because the GDAL library required by GeoDjango is not installed, so no test failures attributable to the change were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ffb89b80832db9facc6582bf20ac)