### PR TITLE
Refine role-permission mapping for organization membership roles

### DIFF
--- a/django/gompet_new/users/role_permissions.py
+++ b/django/gompet_new/users/role_permissions.py
@@ -7,6 +7,7 @@ from .models import MemberRole, OrganizationMember, UserRole
 ROLE_GROUP_PREFIX = "member_role_"
 USER_ROLE_GROUP_PREFIX = "user_role_"
 
+
 APP_MODELS = {
     "users": [
         "user",
@@ -34,16 +35,20 @@ APP_MODELS = {
 
 ACTIONS_VIEW = ("view",)
 ACTIONS_EDIT = ("add", "change", "view")
+ACTIONS_MODERATE = ("change", "delete", "view")
 ACTIONS_FULL = ("add", "change", "delete", "view")
 
-# Opis akcji (permissions):
-# - ACTIONS_VIEW: tylko prawo do podglądu obiektów (read-only).
-# - ACTIONS_EDIT: prawa do dodawania, edycji i podglądu (create/update/read).
-# - ACTIONS_FULL: pełne prawa obejmujące tworzenie, edycję, usuwanie i podgląd (CRUD).
 
-
-def _build_permissions(app_label: str, models: Iterable[str], actions: Iterable[str]) -> list[str]:
-    return [f"{app_label}.{action}_{model}" for model in models for action in actions]
+def _build_permissions(
+    app_label: str,
+    models: Iterable[str],
+    actions: Iterable[str],
+) -> list[str]:
+    return [
+        f"{app_label}.{action}_{model}"
+        for model in models
+        for action in actions
+    ]
 
 
 ALL_VIEW_PERMISSIONS = [
@@ -58,82 +63,258 @@ ALL_FULL_PERMISSIONS = [
     for permission in _build_permissions(app_label, models, ACTIONS_FULL)
 ]
 
-USERS_EDIT_PERMISSIONS = _build_permissions(
+
+ORGANIZATION_VIEW_PERMISSIONS = _build_permissions(
     "users",
-    ["organization", "organizationmember", "address", "species", "breedingtype"],
+    [
+        "organization",
+        "address",
+        "species",
+        "breedingtype",
+        "breedingtypeorganizations",
+    ],
+    ACTIONS_VIEW,
+)
+
+ORGANIZATION_EDIT_PERMISSIONS = _build_permissions(
+    "users",
+    [
+        "organization",
+        "address",
+        "breedingtype",
+        "breedingtypeorganizations",
+    ],
     ACTIONS_EDIT,
 )
-USERS_ADMIN_PERMISSIONS = _build_permissions("users", ["user"], ACTIONS_FULL)
-ANIMALS_EDIT_PERMISSIONS = _build_permissions("animals", APP_MODELS["animals"], ACTIONS_EDIT)
-POSTS_EDIT_PERMISSIONS = _build_permissions("posts", APP_MODELS["posts"], ACTIONS_EDIT)
-ARTICLES_EDIT_PERMISSIONS = _build_permissions("articles", APP_MODELS["articles"], ACTIONS_EDIT)
-LITTERS_EDIT_PERMISSIONS = _build_permissions("litters", APP_MODELS["litters"], ACTIONS_EDIT)
-COMMON_EDIT_PERMISSIONS = _build_permissions("common", ["comment", "reaction"], ACTIONS_EDIT)
-COMMON_MODERATE_PERMISSIONS = _build_permissions(
-    "common", ["comment", "reaction"], ("change", "delete", "view")
+
+ORGANIZATION_FULL_PERMISSIONS = _build_permissions(
+    "users",
+    [
+        "organization",
+        "address",
+        "breedingtype",
+        "breedingtypeorganizations",
+    ],
+    ACTIONS_FULL,
 )
-POSTS_MODERATE_PERMISSIONS = _build_permissions("posts", ["post"], ("change", "delete", "view"))
+
+ORGANIZATION_MEMBERS_VIEW_PERMISSIONS = _build_permissions(
+    "users",
+    ["organizationmember"],
+    ACTIONS_VIEW,
+)
+
+ORGANIZATION_MEMBERS_EDIT_PERMISSIONS = _build_permissions(
+    "users",
+    ["organizationmember"],
+    ACTIONS_EDIT,
+)
+
+ORGANIZATION_MEMBERS_FULL_PERMISSIONS = _build_permissions(
+    "users",
+    ["organizationmember"],
+    ACTIONS_FULL,
+)
+
+USERS_VIEW_PERMISSIONS = _build_permissions(
+    "users",
+    ["user"],
+    ACTIONS_VIEW,
+)
+
+USERS_ADMIN_PERMISSIONS = _build_permissions(
+    "users",
+    ["user"],
+    ACTIONS_FULL,
+)
+
+
+ANIMALS_VIEW_PERMISSIONS = _build_permissions(
+    "animals",
+    APP_MODELS["animals"],
+    ACTIONS_VIEW,
+)
+
+ANIMALS_EDIT_PERMISSIONS = _build_permissions(
+    "animals",
+    APP_MODELS["animals"],
+    ACTIONS_EDIT,
+)
+
+ANIMALS_FULL_PERMISSIONS = _build_permissions(
+    "animals",
+    APP_MODELS["animals"],
+    ACTIONS_FULL,
+)
+
+ANIMAL_GALLERY_EDIT_PERMISSIONS = _build_permissions(
+    "animals",
+    ["animalgallery"],
+    ACTIONS_EDIT,
+)
+
+
+LITTERS_VIEW_PERMISSIONS = _build_permissions(
+    "litters",
+    APP_MODELS["litters"],
+    ACTIONS_VIEW,
+)
+
+LITTERS_EDIT_PERMISSIONS = _build_permissions(
+    "litters",
+    APP_MODELS["litters"],
+    ACTIONS_EDIT,
+)
+
+LITTERS_FULL_PERMISSIONS = _build_permissions(
+    "litters",
+    APP_MODELS["litters"],
+    ACTIONS_FULL,
+)
+
+
+POSTS_VIEW_PERMISSIONS = _build_permissions(
+    "posts",
+    ["post"],
+    ACTIONS_VIEW,
+)
+
+POSTS_CREATE_EDIT_PERMISSIONS = _build_permissions(
+    "posts",
+    ["post"],
+    ACTIONS_EDIT,
+)
+
+POSTS_FULL_PERMISSIONS = _build_permissions(
+    "posts",
+    ["post"],
+    ACTIONS_FULL,
+)
+
+POSTS_MODERATE_PERMISSIONS = _build_permissions(
+    "posts",
+    ["post"],
+    ACTIONS_MODERATE,
+)
+
+
+ARTICLES_VIEW_PERMISSIONS = _build_permissions(
+    "articles",
+    APP_MODELS["articles"],
+    ACTIONS_VIEW,
+)
+
+ARTICLES_EDIT_PERMISSIONS = _build_permissions(
+    "articles",
+    APP_MODELS["articles"],
+    ACTIONS_EDIT,
+)
+
+ARTICLES_FULL_PERMISSIONS = _build_permissions(
+    "articles",
+    APP_MODELS["articles"],
+    ACTIONS_FULL,
+)
+
+
+COMMON_VIEW_PERMISSIONS = _build_permissions(
+    "common",
+    APP_MODELS["common"],
+    ACTIONS_VIEW,
+)
+
+COMMENTS_REACTIONS_CREATE_EDIT_PERMISSIONS = _build_permissions(
+    "common",
+    ["comment", "reaction"],
+    ACTIONS_EDIT,
+)
+
+COMMENTS_REACTIONS_MODERATE_PERMISSIONS = _build_permissions(
+    "common",
+    ["comment", "reaction"],
+    ACTIONS_MODERATE,
+)
+
+NOTIFICATIONS_VIEW_PERMISSIONS = _build_permissions(
+    "common",
+    ["notification"],
+    ACTIONS_VIEW,
+)
+
+
+PUBLIC_VIEW_PERMISSIONS = [
+    *ORGANIZATION_VIEW_PERMISSIONS,
+    *ANIMALS_VIEW_PERMISSIONS,
+    *LITTERS_VIEW_PERMISSIONS,
+    *POSTS_VIEW_PERMISSIONS,
+    *ARTICLES_VIEW_PERMISSIONS,
+    *_build_permissions("common", ["comment", "reaction"], ACTIONS_VIEW),
+]
+
+
+PARTNER_VIEW_PERMISSIONS = [
+    *PUBLIC_VIEW_PERMISSIONS,
+    *ORGANIZATION_MEMBERS_VIEW_PERMISSIONS,
+    *USERS_VIEW_PERMISSIONS,
+    *NOTIFICATIONS_VIEW_PERMISSIONS,
+]
 
 
 ROLE_PERMISSIONS = {
-    # OWNER: pełne uprawnienia do wszystkich modeli aplikacji oraz
-    # dodatkowe uprawnienia administracyjne do modelu użytkownika.
     MemberRole.OWNER: [
-        *ALL_FULL_PERMISSIONS,
-        *USERS_ADMIN_PERMISSIONS,
+        *PUBLIC_VIEW_PERMISSIONS,
+        *ORGANIZATION_FULL_PERMISSIONS,
+        *ORGANIZATION_MEMBERS_FULL_PERMISSIONS,
+        *ANIMALS_FULL_PERMISSIONS,
+        *LITTERS_FULL_PERMISSIONS,
+        *POSTS_FULL_PERMISSIONS,
+        *ARTICLES_FULL_PERMISSIONS,
+        *COMMENTS_REACTIONS_MODERATE_PERMISSIONS,
+        *USERS_VIEW_PERMISSIONS,
+        *NOTIFICATIONS_VIEW_PERMISSIONS,
     ],
-    # STAFF: dostęp do podglądu wszystkiego oraz prawa edycyjne do
-    # użytkowników/organizacji, zwierząt, postów, artykułów, miotów i wspólnych zasobów.
     MemberRole.STAFF: [
-        *ALL_VIEW_PERMISSIONS,
-        *USERS_EDIT_PERMISSIONS,
+        *PUBLIC_VIEW_PERMISSIONS,
         *ANIMALS_EDIT_PERMISSIONS,
-        *POSTS_EDIT_PERMISSIONS,
-        *ARTICLES_EDIT_PERMISSIONS,
         *LITTERS_EDIT_PERMISSIONS,
-        *COMMON_EDIT_PERMISSIONS,
+        *POSTS_CREATE_EDIT_PERMISSIONS,
+        *COMMENTS_REACTIONS_CREATE_EDIT_PERMISSIONS,
     ],
-    # VOLUNTEER: tylko prawo do podglądu wszystkich zasobów.
-    MemberRole.VOLUNTEER: [
-        *ALL_VIEW_PERMISSIONS,
-    ],
-    # MODERATOR: prawo do podglądu oraz moderacji postów i komentarzy (zmiana/usuwanie).
     MemberRole.MODERATOR: [
-        *ALL_VIEW_PERMISSIONS,
+        *PUBLIC_VIEW_PERMISSIONS,
         *POSTS_MODERATE_PERMISSIONS,
-        *COMMON_MODERATE_PERMISSIONS,
+        *COMMENTS_REACTIONS_MODERATE_PERMISSIONS,
+        *USERS_VIEW_PERMISSIONS,
     ],
-    # PARTNER: tylko prawo do podglądu wszystkich zasobów.
-    MemberRole.PARTNER: [
-        *ALL_VIEW_PERMISSIONS,
-    ],
-    # FINANCE: prawo do podglądu oraz edycji wybranych zasobów związanych z użytkownikami/organizacją.
-    MemberRole.FINANCE: [
-        *ALL_VIEW_PERMISSIONS,
-        *USERS_EDIT_PERMISSIONS,
-    ],
-    # CONTENT: prawo do podglądu oraz edycji treści (posty i artykuły).
     MemberRole.CONTENT: [
-        *ALL_VIEW_PERMISSIONS,
-        *POSTS_EDIT_PERMISSIONS,
-        *ARTICLES_EDIT_PERMISSIONS,
+        *PUBLIC_VIEW_PERMISSIONS,
+        *POSTS_CREATE_EDIT_PERMISSIONS,
+        *ANIMAL_GALLERY_EDIT_PERMISSIONS,
+        *COMMENTS_REACTIONS_CREATE_EDIT_PERMISSIONS,
     ],
-    # VIEWER: tylko prawo do podglądu wszystkich zasobów (read-only), podobne do VOLUNTEER.
+    MemberRole.VOLUNTEER: [
+        *PUBLIC_VIEW_PERMISSIONS,
+        *POSTS_CREATE_EDIT_PERMISSIONS,
+        *ANIMAL_GALLERY_EDIT_PERMISSIONS,
+    ],
+    MemberRole.PARTNER: [
+        *PARTNER_VIEW_PERMISSIONS,
+    ],
     MemberRole.VIEWER: [
-        *ALL_VIEW_PERMISSIONS,
+        *PUBLIC_VIEW_PERMISSIONS,
     ],
 }
 
-# Basic user roles outside of organization membership.
+
 USER_ROLE_PERMISSIONS = {
-    "LIMITED": [
+    UserRole.LIMITED.value: [
         *_build_permissions("users", ["organization"], ("add", "view")),
-        *_build_permissions("animals", ["animal"], ("add", "change", "view", "delete")),
-        *_build_permissions("posts", ["post"], ("add", "view")),
-        *_build_permissions("articles", ["article"], ("add", "view", "change", "delete")),
-        *_build_permissions("litters", ["litter"], ("add", "view")),
-        *_build_permissions("common", ["comment", "reaction"], ("add", "view", "change", "delete")),
         *_build_permissions("users", ["organizationmember"], ("add", "view")),
+        *_build_permissions("animals", ["animal"], ("add", "change", "view")),
+        *_build_permissions("posts", ["post"], ("add", "change", "view")),
+        *_build_permissions("articles", ["article"], ("add", "change", "view")),
+        *_build_permissions("litters", ["litter"], ("add", "view")),
+        *_build_permissions("common", ["comment", "reaction"], ("add", "change", "view")),
     ],
 }
 
@@ -146,16 +327,27 @@ def user_role_group_name(role: str) -> str:
     return f"{USER_ROLE_GROUP_PREFIX}{role}"
 
 
-def _resolve_permissions(permission_codes: Iterable[str], using: str | None = None):
+def _resolve_permissions(
+    permission_codes: Iterable[str],
+    using: str | None = None,
+) -> list[Permission]:
     permissions = []
+
     for permission_code in permission_codes:
         app_label, codename = permission_code.split(".", maxsplit=1)
-        permission = Permission.objects.using(using).filter(
-            content_type__app_label=app_label,
-            codename=codename,
-        ).first()
+
+        permission = (
+            Permission.objects.using(using)
+            .filter(
+                content_type__app_label=app_label,
+                codename=codename,
+            )
+            .first()
+        )
+
         if permission:
             permissions.append(permission)
+
     return permissions
 
 
@@ -164,7 +356,12 @@ def ensure_member_role_groups(using: str | None = None) -> None:
         group, _ = Group.objects.using(using).get_or_create(
             name=member_role_group_name(role.value)
         )
-        permissions = _resolve_permissions(ROLE_PERMISSIONS.get(role, []), using=using)
+
+        permissions = _resolve_permissions(
+            ROLE_PERMISSIONS.get(role, []),
+            using=using,
+        )
+
         group.permissions.set(permissions)
 
 
@@ -173,23 +370,29 @@ def ensure_user_role_groups(using: str | None = None) -> None:
         group, _ = Group.objects.using(using).get_or_create(
             name=user_role_group_name(role.value)
         )
+
         permissions = _resolve_permissions(
-            USER_ROLE_PERMISSIONS.get(role.value, []), using=using
+            USER_ROLE_PERMISSIONS.get(role.value, []),
+            using=using,
         )
+
         group.permissions.set(permissions)
 
 
 def sync_user_member_role_groups(user, using: str | None = None) -> None:
     ensure_member_role_groups(using=using)
+
     role_values = set(
         OrganizationMember.objects.using(using)
         .filter(user=user)
         .values_list("role", flat=True)
     )
+
     for role in MemberRole:
         group, _ = Group.objects.using(using).get_or_create(
             name=member_role_group_name(role.value)
         )
+
         if role.value in role_values:
             user.groups.add(group)
         else:
@@ -198,10 +401,12 @@ def sync_user_member_role_groups(user, using: str | None = None) -> None:
 
 def sync_user_role_groups(user, using: str | None = None) -> None:
     ensure_user_role_groups(using=using)
+
     for role in UserRole:
         group, _ = Group.objects.using(using).get_or_create(
             name=user_role_group_name(role.value)
         )
+
         if user.role == role.value:
             user.groups.add(group)
         else:


### PR DESCRIPTION
### Motivation
- Align Django group permissions to the requested organization member roles: `OWNER`, `STAFF`, `MODERATOR`, `CONTENT`, `VOLUNTEER`, `PARTNER`, and `VIEWER`.
- Remove overly-broad global user admin powers from organization roles (avoid granting global `delete_user`/full user admin by default).
- Provide clearer permission bundles for public, partner, moderation and scoped edit operations across domains (users, animals, litters, posts, articles, common).
- Make explicit that object-level constraints (e.g. volunteer-only-for-animal-posts, partner-sees-members-not-requests, owner-sees-requests) must be enforced in querysets/serializers/custom permission classes rather than via global Group permissions.

### Description
- Replaced the previous coarse `ROLE_PERMISSIONS` mapping with a role-aligned mapping for `OWNER`, `STAFF`, `MODERATOR`, `CONTENT`, `VOLUNTEER`, `PARTNER`, and `VIEWER` using targeted permission bundles (e.g. `ORGANIZATION_*`, `ANIMALS_*`, `POSTS_*`, `COMMENTS_REACTIONS_*`).
- Introduced `ACTIONS_MODERATE` and new grouped permission constants such as `PUBLIC_VIEW_PERMISSIONS` and `PARTNER_VIEW_PERMISSIONS` to centralize common view/edit/moderate sets.
- Updated `USER_ROLE_PERMISSIONS` for the `LIMITED` user role to remove broad delete permissions and restrict to add/change/view where appropriate.
- Kept and adjusted helper functions (`_build_permissions`, `_resolve_permissions`, `ensure_*_role_groups`, `sync_user_*_role_groups`) and added small typing/formatting improvements while preserving group sync behaviour.

### Testing
- Ran `python -m compileall django/gompet_new/users/role_permissions.py` and the file compiled successfully.
- No additional automated unit tests were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75d9f8a60832d863995b9f53fb05c)